### PR TITLE
Slate class and test update

### DIFF
--- a/force-app/main/default/classes/SlateIntegrationBatch.cls
+++ b/force-app/main/default/classes/SlateIntegrationBatch.cls
@@ -4,22 +4,30 @@ global class SlateIntegrationBatch implements Database.Batchable<Object>, Databa
     global void execute(SchedulableContext ctx){
         List<hed__Term__c> termList = new List<hed__Term__c>([SELECT Id, Name FROM hed__Term__c WHERE RecordType.Name = 'Credit']);
 
+        //Lookup for accounts to generate a Program List, using Schema to ensure the correct record Type Id
+        Id academicProgramId = Schema.SObjectType.Account.getRecordTypeInfosByDeveloperName().get('Academic_Program').getRecordTypeId();
 
-        SlateIntegrationBatch updateDonationsBatch = new SlateIntegrationBatch(termList);
+        List<Account> acadList = new List<Account>([SELECT Id, hed__School_Code__c FROM Account WHERE RecordTypeId =: academicProgramId]);
+
+        SlateIntegrationBatch updateDonationsBatch = new SlateIntegrationBatch(termList,acadList);
         Database.executebatch(updateDonationsBatch, 200);
     }
     // Set Term lookup
 
     public List<hed__term__c> termIterable;
 
-    public SlateIntegrationBatch(List<hed__term__c> termIterable) {
-        this.termIterable = termIterable;
+    public List<Account> accountIterable;
+
+    public SlateIntegrationBatch(List<hed__term__c> termIterableLIST, List<Account> accountIterableLIST) {
+        this.termIterable = termIterableLIST;
+        this.accountIterable = accountIterableLIST;
     }
 
-    public static Id termHandler (String slateTermTxt, List<hed__Term__c> terms) {
+    @TestVisible private static Id termHandler (String slateTermTxt, List<hed__Term__c> terms) {
         Id returnTermId;
+        String processedTerm = slateTermTxt.replace(' Freshman','').replace(' Transfer','').replace(' Non-Degree','').replace(' Second Bachelor/Post-Bachelor','');
         for (hed__Term__c trow: terms) {
-            if(trow.Name == slateTermTxt) {
+            if(trow.Name == processedTerm) {
                 returnTermId = trow.Id;
                 return returnTermId;
             }
@@ -28,33 +36,123 @@ global class SlateIntegrationBatch implements Database.Batchable<Object>, Databa
         return returnTermId;
     }
 
+    @TestVisible private static String undergradHandler(String slateTermStr) {
+        String undergradValue;
+        if (slateTermStr.contains('Freshman')) {
+            undergradValue = 'Freshman';
+        } else if (slateTermStr.contains('Transfer')) {
+            undergradValue = 'Transfer';
+
+        } else if (slateTermStr.contains('Second Bachelor')) {
+            undergradValue = 'Second Bachelor/Post-Bachelor';
+
+        } else if (slateTermStr.contains('Non-Degree')) {
+            undergradValue = 'Non-Degree';
+
+        } else {
+            undergradValue = '';
+        }
+
+        return undergradValue;
+    }
+
+    @TestVisible private static Id acadAcctHandler (String programCode, List<Account> acadAcctList) {
+        Id acctId;
+        for (Account actRow: acadAcctList) {
+            if(actRow.hed__School_Code__c == programCode) {
+                acctId = actRow.Id;
+                return acctId;
+            }
+        }
+
+        return acctId;
+    }
+
+    //Simplify the setup of a SSR, set to instance vs. static so this.variableName can be accessed
+    @TestVisible private Slate_Staging_Record__c recordHandler(ROW rowItem, List<Account> acctLst, List<hed__Term__c> termLst) {
+        Slate_Staging_Record__c stagingObj = new Slate_Staging_Record__c();
+        stagingObj.Slate_Id__c = rowItem.slateId;
+        stagingObj.CSU_Id__c = rowItem.CSUID;
+
+        if(rowItem.name.split(',').size() > 1) {
+            stagingObj.FirstName__c = rowItem.name.split(',').get(1);
+            stagingObj.Name__c = rowItem.name.split(',').get(0);
+        } else {
+            stagingObj.Name__c = rowItem.name;
+        }
+        
+
+        //This modification makes the TERM record management more important... Without a program CREDIT term record the application term match won't work...
+        if(!String.isBlank(rowItem.term)){
+            stagingObj.Application_Term__c = termHandler(rowItem.term,termIterable);
+            stagingObj.Undergrad_Status__c = undergradHandler(rowItem.term);
+        }
+
+        stagingObj.AppStatus__c = rowItem.appStatus;
+        stagingObj.Decision__c = rowItem.decision;
+
+        if(rowItem.appStatus == 'Awaiting Submission'){
+            stagingObj.Awaiting_Submission__c = true;
+        }
+
+        //Modification to set program
+        if(!String.isBlank(rowItem.currentProgramCode)){
+            Id accountId = acadAcctHandler(rowItem.currentProgramCode,accountIterable);
+            
+            if(accountId != null) {
+                stagingObj.Application_Program__c = accountId;
+            } else {
+                stagingObj.CurrentProgramCode__c = rowItem.currentProgramCode;
+                stagingObj.CurrentSiteCode__c = rowItem.currentSiteCode;
+            }
+
+        }
+        
+        stagingObj.MissingChecklistItems__c = rowItem.missingChecklistItems;
+        stagingObj.FulfilledChecklistItems__c = rowItem.fulfilledChecklistItems;
+        stagingObj.Email1__c = !String.isBlank(rowItem.email1) ? rowItem.email1 : '';
+        stagingObj.Email2__c = !String.isBlank(rowItem.email2) ? rowItem.email2 : '';
+        stagingObj.Email3__c = !String.isBlank(rowItem.email3) ? rowItem.email3 : '';
+        stagingObj.DevicePrimaryPhone1__c = rowItem.devicePrimaryPhone1;
+        stagingObj.OfficialGPA__c = rowItem.OfficialGPA;
+        Date dT;
+        if(!String.isBlank(rowItem.createdDate)) {
+            List<String> strDT = rowItem.createdDate.split('T');
+            dt = Date.ValueOf(strDT[0]);
+        }
+        stagingObj.CreatedDate__c = dt != null ?  dt : null;
+
+        return stagingObj;
+    }
+
+    //Actual Schedule Components
 
     global Iterable<Object> start(Database.BatchableContext bc) {
         List<object> objList = new List<Object>();
         
-        HttpRequest req = new HttpRequest();
-        req.setEndpoint('callout:Slate_Grad/manage/query/run?id=330b9299-5efa-452a-a9d3-e25c89add368&cmd=service&output=json&h=cd189a82-0b2c-4ee9-a52e-e384fd52d84d');
-        req.setMethod('GET');
-        req.setTimeout(120000);
-        Http http = new Http();
-        HTTPResponse res = http.send(req);
-        for(Row r : ((SlateWrapperClass)JSON.deserialize(res.getBody(), SlateWrapperClass.class)).row) {
+        HttpRequest reqGr = new HttpRequest();
+        reqGr.setEndpoint('callout:Slate_Grad/manage/query/run?id=330b9299-5efa-452a-a9d3-e25c89add368&cmd=service&output=json&h=cd189a82-0b2c-4ee9-a52e-e384fd52d84d');
+        reqGr.setMethod('GET');
+        reqGr.setTimeout(120000);
+        Http httpGR = new Http();
+        HTTPResponse resGR = httpGR.send(reqGr);
+        for(Row r : ((SlateWrapperClass)JSON.deserialize(resGR.getBody(), SlateWrapperClass.class)).row) {
             objList.add(r);
         }
 
         // Undergraduate
 
-        HttpRequest req2 = new HttpRequest();
-        req2.setEndpoint('callout:Slate_UG/manage/query/run?id=b85e0542-ae22-4953-9803-dade45a93f1d&cmd=service&output=json&h=610a2e83-2322-10d2-9150-830446fbb323');
-        req2.setMethod('GET');
-        req2.setTimeout(120000);
-        Http http2 = new Http();
-        HTTPResponse res2 = http2.send(req2);
-        for(Row r : ((SlateWrapperClass)JSON.deserialize(res2.getBody(), SlateWrapperClass.class)).row) {
+        HttpRequest reqUg = new HttpRequest();
+        reqUg.setEndpoint('callout:Slate_UG/manage/query/run?id=b85e0542-ae22-4953-9803-dade45a93f1d&cmd=service&output=json&h=610a2e83-2322-10d2-9150-830446fbb323');
+        reqUg.setMethod('GET');
+        reqUg.setTimeout(120000);
+        Http httpUG = new Http();
+        HTTPResponse resUG = httpUG.send(reqUg);
+        for(Row r : ((SlateWrapperClass)JSON.deserialize(resUG.getBody(), SlateWrapperClass.class)).row) {
             objList.add(r);
         }
 
-        // Handle List
+        // Handle List Deletion to reset SSR
 
         List<Slate_Staging_Record__c> listToDelete = [select id from Slate_Staging_Record__c];
         if(!listToDelete.isEmpty()) {
@@ -63,39 +161,15 @@ global class SlateIntegrationBatch implements Database.Batchable<Object>, Databa
         return objList;
     }
 
+    //Actual execute
+
     global void execute(Database.BatchableContext bc, List<object> scope){
         List<Slate_Staging_Record__c> listToInsert = new List<Slate_Staging_Record__c>();
         for(Object o: scope){
             Row stagingResObj = (ROW)o;
-            Slate_Staging_Record__c stagingObj = new Slate_Staging_Record__c();
-            stagingObj.Slate_Id__c = stagingResObj.slateId;
-            stagingObj.CSU_Id__c = !String.isBlank(stagingResObj.CSUID) ? stagingResObj.csuId : '';
-            stagingObj.FirstName__c = stagingResObj.name.split(',').size() > 1 ? stagingResObj.name.split(',').get(1) : '';
-            stagingObj.Name__c = stagingResObj.name.split(',').size() > 0 ? stagingResObj.name.split(',').get(0) : '';
-            //stagingObj.Term__c = stagingResObj.term;
-            //This modification makes the TERM record management more important... Without a program CREDIT term record the application term match won't work...
-            if(!String.isBlank(stagingResObj.term)){
-                String processedTerm = stagingResObj.term.replace(' Freshman','').replace(' Transfer','').replace(' Non-Degree','').replace(' Second Bachelor/Post-Bachelor','');
-                stagingObj.Application_Term__c = termHandler(processedTerm,termIterable);
-            }
-            stagingObj.AppStatus__c = !String.isBlank(stagingResObj.appStatus) ? stagingResObj.appStatus : '';
-            stagingObj.CurrentProgramCode__c = !String.isBlank(stagingResObj.currentProgramCode) ? stagingResObj.currentProgramCode : '';
-            stagingObj.CurrentSiteCode__c = !String.isBlank(stagingResObj.currentSiteCode) ? stagingResObj.currentSiteCode : '';
-            stagingObj.Decision__c = !String.isBlank(stagingResObj.decision) ? stagingResObj.decision : '';
-            stagingObj.MissingChecklistItems__c = !String.isBlank(stagingResObj.missingChecklistItems) ? stagingResObj.missingChecklistItems : '';
-            stagingObj.FulfilledChecklistItems__c = !String.isBlank(stagingResObj.fulfilledChecklistItems) ? stagingResObj.fulfilledChecklistItems : '';
-            stagingObj.Email1__c = !String.isBlank(stagingResObj.email1) ? stagingResObj.email1 : '';
-            stagingObj.Email2__c = !String.isBlank(stagingResObj.email2) ? stagingResObj.email2 : '';
-            stagingObj.Email3__c = !String.isBlank(stagingResObj.email3) ? stagingResObj.email3 : '';
-            stagingObj.DevicePrimaryPhone1__c = !String.isBlank(stagingResObj.devicePrimaryPhone1) ? stagingResObj.devicePrimaryPhone1 : '';
-            stagingObj.OfficialGPA__c = !String.isBlank(stagingResObj.OfficialGPA) ? stagingResObj.officialGPA : '';
-            Date dT;
-            if(!String.isBlank(stagingResObj.createdDate)) {
-                List<String> strDT = stagingResObj.createdDate.split('T');
-                dt = Date.ValueOf(strDT[0]);
-            }
-            stagingObj.CreatedDate__c = dt != null ?  dt : null;
-            listToInsert.add(stagingObj);
+            Slate_Staging_Record__c stageObjToAdd = new Slate_Staging_Record__c();
+            stageObjToAdd = recordHandler(stagingResObj,accountIterable,termIterable);
+            listToInsert.add(stageObjToAdd);
         }
         try {
             insert listToInsert;
@@ -112,6 +186,7 @@ global class SlateIntegrationBatch implements Database.Batchable<Object>, Databa
         public List<Row> row;
     }
     
+    // Row contains all fields from Slate, match columns returned by URL
     public Class Row {
         public String slateId;
         public String csuId;
@@ -131,5 +206,6 @@ global class SlateIntegrationBatch implements Database.Batchable<Object>, Databa
         public String credits;
         public String officialGPA;
         public String createdDate;
-    }    
+    }
+
 }

--- a/force-app/main/default/classes/SlateIntegrationBatch.cls
+++ b/force-app/main/default/classes/SlateIntegrationBatch.cls
@@ -111,9 +111,11 @@ global class SlateIntegrationBatch implements Database.Batchable<Object>, Databa
             if(accountId != null) {
                 stagingObj.Application_Program__c = accountId;
                 stagingObj.CurrentProgramCode__c = rowItem.currentProgramCode;
+                stagingObj.CurrentSiteCode__c = rowItem.currentSiteCode;
             } else {
                 stagingObj.CurrentProgramCode__c = rowItem.currentProgramCode;
                 stagingObj.CurrentSiteCode__c = rowItem.currentSiteCode;
+                stagingObj.Program_Missing__c = true;
             }
 
         }

--- a/force-app/main/default/classes/SlateIntegrationBatch.cls
+++ b/force-app/main/default/classes/SlateIntegrationBatch.cls
@@ -7,7 +7,7 @@ global class SlateIntegrationBatch implements Database.Batchable<Object>, Databa
         //Lookup for accounts to generate a Program List, using Schema to ensure the correct record Type Id
         Id academicProgramId = Schema.SObjectType.Account.getRecordTypeInfosByDeveloperName().get('Academic_Program').getRecordTypeId();
 
-        List<Account> acadList = new List<Account>([SELECT Id, hed__School_Code__c FROM Account WHERE RecordTypeId =: academicProgramId]);
+        List<Account> acadList = new List<Account>([SELECT Id, hed__School_Code__c FROM Account WHERE RecordTypeId =: academicProgramId AND hed__School_Code__c != '']);
 
         SlateIntegrationBatch updateDonationsBatch = new SlateIntegrationBatch(termList,acadList);
         Database.executebatch(updateDonationsBatch, 200);
@@ -58,10 +58,19 @@ global class SlateIntegrationBatch implements Database.Batchable<Object>, Databa
 
     @TestVisible private static Id acadAcctHandler (String programCode, List<Account> acadAcctList) {
         Id acctId;
+
+        String regEXP = '-[A-Za-z]+-';
+        String programCodeSF = '';
+
         for (Account actRow: acadAcctList) {
-            if(actRow.hed__School_Code__c == programCode) {
+            programCodeSF = actRow.hed__School_Code__c;
+
+            if(programCodeSF == programCode) {
                 acctId = actRow.Id;
-                return acctId;
+                break;
+            } else if (programCodeSF?.replaceFirst(regEXP,'-') == programCode.replaceFirst(regEXP,'-')){
+                acctId = actRow.Id;
+                break;
             }
         }
 
@@ -101,6 +110,7 @@ global class SlateIntegrationBatch implements Database.Batchable<Object>, Databa
             
             if(accountId != null) {
                 stagingObj.Application_Program__c = accountId;
+                stagingObj.CurrentProgramCode__c = rowItem.currentProgramCode;
             } else {
                 stagingObj.CurrentProgramCode__c = rowItem.currentProgramCode;
                 stagingObj.CurrentSiteCode__c = rowItem.currentSiteCode;

--- a/force-app/main/default/classes/SlateIntegrationBatchTest.cls
+++ b/force-app/main/default/classes/SlateIntegrationBatchTest.cls
@@ -1,35 +1,86 @@
 @isTest
-global class SlateIntegrationBatchTest {
+public class SlateIntegrationBatchTest {
 
 
     @TestSetup
     private static void makeData(){
-        Account a = new Account();
-        a.Name = 'CSU';
+        Id academicProgramId = Schema.SObjectType.Account.getRecordTypeInfosByDeveloperName().get('Academic_Program').getRecordTypeId();
+        Id cTermId = Schema.SObjectType.hed__Term__c.getRecordTypeInfosByDeveloperName().get('Credit').getRecordTypeId();
+
+
+        Account a = new Account(
+            Name = 'CSU'
+        );
         insert a;
-        hed__term__c t = new hed__term__c();
-        t.Name = 'Summer 2022';
-        t.hed__Account__c = a.id;
+
+        Account p = new Account(
+            Name = 'CSU Program A',
+            hed__school_code__c = 'TEST-PROGRAM-A',
+            RecordTypeId = academicProgramId
+        );
+
+        insert p;
+
+        Account ptwo = new Account(
+            Name = 'CSU Program B',
+            hed__school_code__c = 'TEST-PROGRAM-B',
+            RecordTypeId = academicProgramId
+        );
+
+        insert ptwo;
+
+
+        hed__term__c t = new hed__term__c(
+            Name = 'Summer 2022',
+            hed__Account__c = a.id,
+            RecordTypeId = cTermId
+        );
+
         insert t;
+
+
     }
-    @isTest global static void testMethod1() {
+    @isTest private static void testMethod1() {
         Test.setMock(HttpCalloutMock.class, new SlateIntegrationMockImpl());
         
         Test.startTest();
         SchedulableContext sc = null;
         List<hed__Term__c> testTerms = new List<hed__Term__c>([SELECT Id, Name FROM hed__Term__c WHERE RecordType.Name = 'Credit']);
-        SlateIntegrationBatch testsche = new SlateIntegrationBatch(testTerms);
+        List<Account> testAccts = new List<Account>([SELECT Id, hed__School_Code__c FROM Account WHERE RecordType.Name = 'Academic Program']);
+        SlateIntegrationBatch testsche = new SlateIntegrationBatch(testTerms,testAccts);
         testsche.execute(sc); 
         Test.stopTest();
-        
+
+        List<AsyncApexJob> jobsApexBatch = [select Id, ApexClassID, ApexClass.Name, Status, JobType from AsyncApexJob where JobType = 'BatchApex'];
+        System.assertEquals(1, jobsApexBatch.size(), 'Batch job should have been scheduled');        
     }
 
-    global class SlateIntegrationMockImpl implements HttpCalloutMock{
-        global HttpResponse respond(HTTPRequest req){
+    @isTest private static void testMethod2() {
+        String termSTR = 'Summer 2022 Freshman';
+        String termSTRF = 'Summer 2022 Freshie';
+        String fN = 'Firster First,Namer Name';
+
+        Test.startTest();
+        String testedVal = SlateIntegrationBatch.undergradHandler(termSTR);
+        String testedValF = SlateIntegrationBatch.undergradHandler(termSTRF);
+
+        List<Account> lAccount = new List<Account>([SELECT Id, hed__School_Code__c FROM Account WHERE RecordType.Name = 'Academic Program']);
+        Id acctTest;
+
+        acctTest = SlateIntegrationBatch.acadAcctHandler('TEST-PROGRAM-B',lAccount);
+
+        system.assert(acctTest!=null,'Account ID not Assigned');
+        system.assertEquals(testedVal,'Freshman','TRUE case error');
+        system.assertEquals(testedValF,'','FALSE case error');
+        Test.stopTest();
+    }
+
+    public class SlateIntegrationMockImpl implements HttpCalloutMock{
+        public HttpResponse respond(HTTPRequest req){
           HttpResponse res = new HttpResponse();
           res.setStatus('OK');
           res.setStatusCode(200);
-          res.setBody('{"row": [{"SlateID": "123456", "Name": "Kyle Winterrowd", "Term":"Summer 2022"}]}');
+          res.setBody('{"row": [{"SlateID": "123456", "Name": "Kyle Winterrowd", "Term":"Summer 2022","currentProgramCode":"TEST-PROGRAM-A"}]}');
           return res;
         }
     }

--- a/force-app/main/default/objects/Slate_Staging_Record__c/fields/Program_Missing__c.field-meta.xml
+++ b/force-app/main/default/objects/Slate_Staging_Record__c/fields/Program_Missing__c.field-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Program_Missing__c</fullName>
+    <defaultValue>false</defaultValue>
+    <externalId>false</externalId>
+    <label>Program Missing</label>
+    <trackTrending>false</trackTrending>
+    <type>Checkbox</type>
+</CustomField>

--- a/force-app/main/default/objects/Slate_Staging_Record__c/fields/Undergrad_Status__c.field-meta.xml
+++ b/force-app/main/default/objects/Slate_Staging_Record__c/fields/Undergrad_Status__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Undergrad_Status__c</fullName>
+    <externalId>false</externalId>
+    <label>Undergrad Status</label>
+    <length>255</length>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>


### PR DESCRIPTION
* Added account lookup on Slate constructor and function to find account directly on the batch class.
* Fixed term lookup on Slate constructor and function to find terms directly on the batch class.
* Added constructor and record handler methods to instantiate the record and run functions to generate student name (split name string), assign programs (find program based on school code and Slate program code), and assign terms (assign credit terms by name). Changed keyword from static to non-static so it can access instance variables passed via scheduler when the state (start, execute, stop) of the batch changes.
* Added undergraduate value field to handle Non-Degree, 2nd/Post-Bac, Freshman, or transfer values.
* Modified test class to include above items. Updated mock HTTP with assert call.
* Reduced cyclomatic complexity to remove error from VS Code extension by moving the constructor and for-loop operations to the handler method and reducing ternaries on each given variable setup (cause why was there a ternary at each field??) also changed classes on test to private/public where relevant